### PR TITLE
[fix] 추천 상세 스크롤 동작 수정

### DIFF
--- a/src/pages/Favorites/FavoriteRecipeDetailPage.tsx
+++ b/src/pages/Favorites/FavoriteRecipeDetailPage.tsx
@@ -90,7 +90,7 @@ export function FavoriteRecipeDetailPage() {
   }
 
   return (
-    <section className="screen-panel">
+    <section className="screen-panel detail-screen">
       <div className="detail-toolbar">
         <Link className="button button--light screen-toolbar__button" to="/favorites">
           ← 즐겨찾기

--- a/src/pages/RecommendationDetail/RecommendationDetailPage.tsx
+++ b/src/pages/RecommendationDetail/RecommendationDetailPage.tsx
@@ -79,7 +79,7 @@ export function RecommendationDetailPage() {
   }
 
   return (
-    <section className="screen-panel">
+    <section className="screen-panel detail-screen">
       <div className="detail-toolbar">
         <Link className="button button--light screen-toolbar__button" to="/recommendations">
           ← 뒤로가기

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -773,6 +773,26 @@ input:focus {
   gap: 18px;
 }
 
+.detail-screen {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-screen .detail-toolbar {
+  flex: 0 0 auto;
+}
+
+.detail-screen .detail-layout {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.detail-screen .detail-card {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .detail-card {
   min-height: 372px;
   padding: 16px;
@@ -1099,6 +1119,10 @@ input:focus {
 
   .detail-card {
     min-height: auto;
+  }
+
+  .detail-screen .detail-card {
+    overflow: visible;
   }
 
   .home-dashboard__hero {


### PR DESCRIPTION
## 작업 내용
- 추천 상세 화면에 내부 스크롤 레이아웃을 적용했습니다.
- 즐겨찾기 레시피 상세 화면에도 동일한 스크롤 레이아웃을 적용했습니다.

## 변경 이유
- 태블릿 고정 화면에서 상세 카드가 overflow hidden 상태라 긴 레시피/팁 내용이 잘리는 문제가 있었습니다.

## 테스트 방법
- npm run build

## 영향 범위
- 추천 상세 화면
- 즐겨찾기 레시피 상세 화면
- 공통 상세 카드 CSS

## 관련 이슈
- Closes #15